### PR TITLE
fix bug where values couldn't be generated

### DIFF
--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -166,7 +166,7 @@ def generate_value(item_id):
 
     sales_data = api_data_to_list(decoded["priceDataPoints"])
     volume_data = api_data_to_list(decoded["volumeDataPoints"])
-    if not sales_data is None or volume_data is None:
+    if sales_data is None or volume_data is None:
         log(f"Failed to parse_date of {item_id}, skipping it")
         return None
 

--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -150,6 +150,7 @@ def generate_value(item_id):
         for item in items:
             dt = parse_date(item["date"])
             if not dt:
+                log(f"got unexpected date from {item}")
                 return None
             timestamp = time.mktime(dt.timetuple())
             value = item["value"]
@@ -165,7 +166,7 @@ def generate_value(item_id):
 
     sales_data = api_data_to_list(decoded["priceDataPoints"])
     volume_data = api_data_to_list(decoded["volumeDataPoints"])
-    if not sales_data or volume_data:
+    if not sales_data is None or volume_data is None:
         log(f"Failed to parse_date of {item_id}, skipping it")
         return None
 


### PR DESCRIPTION
<img width="1351" height="689" alt="image" src="https://github.com/user-attachments/assets/c9aa30a0-4428-40df-87c6-3ea372e46877" />

So I had a logic error last merge, where I accidently added "not" infront of the if statement, causing the bot to skip generating values.