### PR TITLE
migrate send_trade, pull_trade, generate_value and get_inventory to use V2 APIs to fix trading faces.

### DIFF
--- a/otb-legacy-source/authenticator.py
+++ b/otb-legacy-source/authenticator.py
@@ -72,9 +72,8 @@ class AuthHandler:
                 return request.json()["verificationToken"]
             except Exception:
                 log(
-                    "error returning verification token",
-                    request.text,
-                    request.status_code,
+                    f"error returning verification token {request.text} {request.status_code}",
+                    mycolors.FAIL,
                 )
                 continue
 

--- a/otb-legacy-source/getvaluemanual.py
+++ b/otb-legacy-source/getvaluemanual.py
@@ -17,13 +17,13 @@ def calculate_volume(value, volume):
     return volume / ((43951.2 / value) + (-0.00000484931 * value) + 2.43184)
 
 
+# NOTE: generate value takes more than just ID now.
 while True:
     theId = input("Enter ID: ")
 
     item = valuemanager.generate_value(int(theId))
     try:
-        item["ModifiedVolume"] = calculate_volume(
-            item["value"], item["volume"])
+        item["ModifiedVolume"] = calculate_volume(item["value"], item["volume"])
     except ZeroDivisionError:
         item["ModifiedVolume"] = 0.0
 

--- a/otb-legacy-source/getvaluemanual.py
+++ b/otb-legacy-source/getvaluemanual.py
@@ -20,8 +20,12 @@ def calculate_volume(value, volume):
 # NOTE: generate value takes more than just ID now.
 while True:
     theId = input("Enter ID: ")
+    item_payload = {
+        "itemId": int(theId),
+        "name": str(theId)
+    }
 
-    item = valuemanager.generate_value(int(theId))
+    item = valuemanager.generate_value(item_payload)
     try:
         item["ModifiedVolume"] = calculate_volume(item["value"], item["volume"])
     except ZeroDivisionError:

--- a/otb-legacy-source/linucks.py
+++ b/otb-legacy-source/linucks.py
@@ -74,8 +74,7 @@ class daemon:
             pid = None
 
         if pid:
-            message = "pidfile {0} already exist. " + \
-                "Daemon already running?\n"
+            message = "pidfile {0} already exist. " + "Daemon already running?\n"
             sys.stderr.write(message.format(self.pidfile))
             sys.exit(1)
 

--- a/otb-legacy-source/proxy.py
+++ b/otb-legacy-source/proxy.py
@@ -69,8 +69,7 @@ def infinite_loop_proxies():
             yield proxy
 
 
-switch_proxy_every_minutes = int(
-    settings["General"]["switch_proxy_every_minutes"])
+switch_proxy_every_minutes = int(settings["General"]["switch_proxy_every_minutes"])
 
 
 def test_proxy():

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -238,7 +238,8 @@ def get_inventory(user_id):
         data = None
 
         for i in range(5):  # Up to 5 attempts
-            url = f"https://trades.roblox.com/v2/users/{user_id}/tradableItems?sortBy=CreationTime&sortOrder=2&limit=100&cursor={cursor}"
+            # NOTE: limit is 50 because 100 causes internal server error for big inventories
+            url = f"https://trades.roblox.com/v2/users/{user_id}/tradableItems?sortBy=CreationTime&sortOrder=2&limit=50&cursor={cursor}"
 
             response = session.get(url)
 

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -137,8 +137,8 @@ def get_xsrf():
 
 
 def add_extra_info(item):
-    # New method for outbound trades
-    if "Name" not in item:
+    # Statement for item info of v1 APIs (Inventory API)
+    if "buildersClubMembershipType" in item:
         item_name_encoded = item["name"].encode("utf-8")
         item["Name"] = item_name_encoded  # For compatibility
         item["name"] = item_name_encoded
@@ -165,21 +165,41 @@ def add_extra_info(item):
         item["buildersClubMembershipType"] = membership_type
         item["MembershipLevel"] = membership_type
         item["AveragePrice"] = int(item["recentAveragePrice"])
+
+    # Statement for the v2 APIs
     else:
-        # Old method for inbound trades
-        item["name"] = item["Name"]
+        item_name_encoded = item["itemName"].encode("utf-8")
+        item["name"] = item_name_encoded
+        item["Name"] = item_name_encoded
+        item["itemId"] = int(item["itemTarget"]["targetId"])
+        item["AveragePrice"] = int(item["recentAveragePrice"])
 
-        item["itemId"] = int(re.match(r".*/(\d+)/.*", item["ItemLink"]).group(1))
+        # This is a replacement to item_id for bundles
+        collectable_id = item.get("collectibleItemId")
+        item["collectibleItemId"] = collectable_id
 
-        item["AveragePrice"] = int(item["AveragePrice"])
+        item_instance_id = item.get("ItemInstanceId")
 
-    item_data = valuemanager.get_value(item["itemId"])
+        # Add instance Id if its from the trade inventory API
+        if item_instance_id:
+            item["collectibleItemInstanceId"] = item_instance_id
+        else:
+            item_instances = item.get("instances")
+            if item_instances:
+                item_instance_id = item_instances[0]["collectibleItemInstanceId"]
+                item["collectibleItemInstanceId"] = item_instance_id
+
+        item["userAssetId"] = item_instance_id
+        item["itemType"] = item["itemTarget"]["itemType"]
+
+    item_data = valuemanager.get_value(item)
 
     if item_data is None:
         return None
 
     item["value"] = item_data["value"]
     item["OriginalVolume"] = item_data["volume"]
+
     try:
         item["volume"] = calculate_volume(item["value"], item_data["volume"])
     except ZeroDivisionError:
@@ -218,14 +238,8 @@ def get_inventory(user_id):
         data = None
 
         for i in range(5):  # Up to 5 attempts
-            url = (
-                "https://inventory.roblox.com/v1/users/%(userId)i/assets/collectibles?"
-                "cursor=%(cursor)s&sortOrder=Desc&limit=100"
-                % {  # &assetType=%(assetTypeId)i" % {
-                    "userId": int(user_id),
-                    "cursor": cursor,
-                }
-            )  # , "assetTypeId": assetTypeId}
+            url = f"https://trades.roblox.com/v2/users/{user_id}/tradableItems?sortBy=CreationTime&sortOrder=2&limit=100&cursor={cursor}"
+
             response = session.get(url)
 
             data = json.loads(response.text)
@@ -251,7 +265,7 @@ def get_inventory(user_id):
             break
 
         cursor = data["nextPageCursor"]
-        inventory_raw += data["data"]
+        inventory_raw += data["items"]
 
     inventory = []
     for item in inventory_raw:
@@ -272,7 +286,6 @@ def get_inventory(user_id):
         item
         for item in inventory
         if item["value"] <= int(settings["Trading"]["maximum_item_value"])
-        and not item["isOnHold"]
     ]
 
     return inventory
@@ -427,7 +440,9 @@ def trade_side_to_str(side):
 def create_offer(user_id, items, robux):
     return {
         "userId": user_id,
-        "userAssetIds": [item["userAssetId"] for item in items],
+        "collectibleItemInstanceIds": [
+            item["collectibleItemInstanceId"] for item in items
+        ],
         "robux": robux,
     }
 
@@ -473,10 +488,10 @@ def send_trade(
         post_to_webhook=(not is_repeat),
     )
 
-    offers = [
-        create_offer(session.cookies["user_id"], trade[1], 0),
-        create_offer(user_id, trade[2], their_robux),
-    ]
+    offers = {
+        "senderOffer": create_offer(session.cookies["user_id"], trade[1], 0),
+        "recipientOffer": create_offer(user_id, trade[2], their_robux),
+    }
 
     if not skip_clock:
         while clock > 0:
@@ -486,9 +501,9 @@ def send_trade(
 
     if settings["Debugging"]["easy_debug"] != "true" and not testing:
         response = session.post(
-            "https://trades.roblox.com/v1/trades/send",
+            "https://trades.roblox.com/v2/trades/send",
             headers={"X-CSRF-TOKEN": get_xsrf()},
-            json={"offers": offers},
+            json=offers,
         )
 
         data = json.loads(response.text)
@@ -506,8 +521,11 @@ def send_trade(
         #     bl.add_block(user_id)
         #     log("Trade with %i: \"%s\", moving to next partner..." % (user_id, response["msg"]), mycolors.WARNING)
 
-        errors = data["errors"]
-        error_output_text = " ".join([error["message"] for error in errors])
+        if data.get("errors"):
+            errors = data["errors"]
+            error_output_text = " ".join([error["message"] for error in errors])
+        else:
+            error_output_text = data
 
         if response.status_code == 429:
             if "errors" in response.json():
@@ -537,7 +555,10 @@ def send_trade(
                 user_id, trade, skip_clock, trade_id, their_robux, is_repeat=True
             )
         else:
-            log("Failed to send trade. %s" % error_output_text, mycolors.FAIL)
+            log(
+                f"Failed to send trade. {error_output_text} payload: {offers}",
+                mycolors.FAIL,
+            )
             if "Challenge is required to authorize the request" in error_output_text:
                 ok = Authenticator.validate_2fa(response, session)
                 log(f"response from 2fa: {ok}", no_print=True)
@@ -578,7 +599,7 @@ def calculate_score(x):
 
 
 def pull_trade(session_id):
-    response = session.get("https://trades.roblox.com/v1/trades/%i" % session_id)
+    response = session.get("https://trades.roblox.com/v2/trades/%i" % session_id)
 
     data = json.loads(response.text)
 
@@ -644,24 +665,23 @@ def listen_for_inbound_trades():
                 my_offer = None
                 their_offer = None
 
-                for offer in trade_data["offers"]:
-                    if int(offer["user"]["id"]) == int(session.cookies["user_id"]):
-                        my_offer = copy.deepcopy(offer)
-                    else:
-                        their_offer = copy.deepcopy(offer)
-
-                assert my_offer is not None
-                assert their_offer is not None
+                try:
+                    my_offer = copy.deepcopy(trade_data["participantAOffer"])
+                    their_offer = copy.deepcopy(trade_data["participantBOffer"])
+                except:
+                    assert my_offer is not None
+                    assert their_offer is not None
+                    continue
 
                 my_items = [
                     info
-                    for item in my_offer["userAssets"]
+                    for item in my_offer["items"]
                     if (info := add_extra_info(item)) is not None
                 ]
 
                 their_items = [
                     info
-                    for item in their_offer["userAssets"]
+                    for item in their_offer["items"]
                     if (info := add_extra_info(item)) is not None
                 ]
 

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -247,16 +247,15 @@ def get_inventory(user_id):
             # Check for any errors in response
             try:
                 data = json.loads(response.text)
+
+                if "errors" in data:
+                    for err in data["errors"]:
+                        logging.warning("Failed to load inventory: %s", err["message"])
+                    raise FailedToLoadInventoryException
             except json.JSONDecodeError:
                 logging.warning(
                     "Failed to parse inventory JSON on attempt %d", attempt + 1
                 )
-                continue
-            if "errors" in data:
-                for err in data["errors"]:
-                    logging.warning("Failed to load inventory: %s", err["message"])
-
-                raise FailedToLoadInventoryException
 
             # Check for response
             if response.status_code != 200:
@@ -1123,24 +1122,49 @@ tradeSendQueueRunnerThread = threading.Thread(target=trade_send_queue_runner)
 tradeSendQueueRunnerThread.daemon = True
 tradeSendQueueRunnerThread.start()
 
+can_trade_throttle = False
+can_trade_timestamp = 0
+can_trade_backoff = 30
+
 
 def search_for_trades(user_id, guarantee_trade=False):
     log("Searching for trades with %i..." % user_id)
+    # Dont scan the same person..
+    cooldowns.add_cooldown(user_id)
 
     # If precheck is set to false in the lines following, then we will not look for trades with this user.
     precheck = True
 
-    # Check if we are allowed to trade with the user
-    response = session.get(
-        "https://trades.roblox.com/v1/users/%i/can-trade-with" % user_id
-    )
-    # Sometimes Roblox will throttle this,
-    # so in that case just don't bother with checking if we can trade with the user.
-    if response.status_code == 200:
-        data = json.loads(response.text)
-        can_trade_with = data["canTrade"]
-        if not can_trade_with:
-            precheck = False
+    # TODO: Use more APIs to check if can_trade
+    #
+    # Add ratelimit throttle to prevent spamming this API
+    global can_trade_throttle, can_trade_timestamp, can_trade_backoff
+    if can_trade_throttle and time.time() - can_trade_timestamp < 30:
+        # Still throttled, skip the request and assume we can trade
+        pass
+    else:
+        if can_trade_throttle:
+            # 30 seconds have passed, reset throttle
+            can_trade_throttle = False
+            can_trade_backoff = 30
+
+        response = session.get(
+            "https://trades.roblox.com/v1/users/%i/can-trade-with" % user_id
+        )
+
+        if response.status_code == 200:
+            data = json.loads(response.text)
+            can_trade_with = data["canTrade"]
+            if not can_trade_with:
+                precheck = False
+
+        elif response.status_code == 429:
+            can_trade_throttle = True
+            can_trade_timestamp = time.time()
+            can_trade_backoff = min(can_trade_backoff * 2, 180)
+            log(
+                f"can-trade-with throttled, backing off for {can_trade_backoff} seconds"
+            )
 
     # Check that the user is not a Roblox administrator
     is_admin = False
@@ -1158,7 +1182,7 @@ def search_for_trades(user_id, guarantee_trade=False):
                 is_admin = True
                 precheck = False
 
-    if not precheck:
+    if precheck is False:
         if is_admin:
             # log("Skipping user because they're admin.")
             # Block the user
@@ -1172,15 +1196,19 @@ def search_for_trades(user_id, guarantee_trade=False):
         my_inventory = get_inventory(session.cookies["user_id"])
     except FailedToLoadInventoryException:
         log("Failed to load own inventory.", mycolors.FAIL)
+        # Avoid Inventory throttle
+        time.sleep(10)
         logging.exception("Caught exception while getting my_inventory")
         return
     try:
         their_inventory = get_inventory(user_id)
     except FailedToLoadInventoryException:
         log(
-            f"Skipping getting inventory for user {user_id}",
+            f"Skipping getting inventory for user {user_id}...",
             mycolors.WARNING,
         )
+        # Avoid Inventory throttle
+        time.sleep(10)
         logging.exception("Caught exception while getting their inventory")
         return
 

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -290,7 +290,8 @@ def get_inventory(user_id):
         try:
             new_item = add_extra_info(item)
         except Exception as e:
-            log(f"skipping item from fetching inventory")
+            log(f"skipping item from fetching inventory: {e}", mycolors.FAIL)
+            continue
         if new_item is None:
             continue
         # Only do this for our inventory
@@ -744,7 +745,7 @@ def listen_for_inbound_trades():
                         if (info := add_extra_info(item)) is not None
                     ]
                 except Exception as e:
-                    log(f"failed to add item data to inbound trade", mycolors.FAIL)
+                    log(f"failed to add item data to inbound trade: {e}", mycolors.FAIL)
                     continue
 
                 my_items_original = copy.deepcopy(my_items)

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 import itertools
 import json
 import logging

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -231,6 +231,7 @@ def get_inventory(user_id):
         for attempt in range(MAX_RETRIES):
             response = session.get(url)
             if response.status_code == 200:
+                data = json.loads(response.text)
                 break
             elif response.status_code == 429:
                 log(

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -291,6 +291,7 @@ def get_inventory(user_id):
             new_item = add_extra_info(item)
         except Exception as e:
             log(f"skipping item from fetching inventory: {e}", mycolors.FAIL)
+            logging.exception(e)
             continue
         if new_item is None:
             continue
@@ -746,6 +747,8 @@ def listen_for_inbound_trades():
                     ]
                 except Exception as e:
                     log(f"failed to add item data to inbound trade: {e}", mycolors.FAIL)
+                    logging.exception(e)
+
                     continue
 
                 my_items_original = copy.deepcopy(my_items)

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -243,15 +243,8 @@ def get_inventory(user_id):
                 )
                 time.sleep(10)
                 continue
-            if response.status_code != 200:
-                log(
-                    f"Inventory request failed with status {
-                        response.status_code
-                    }. Attempt {attempt + 1}/{MAX_RETRIES}.",
-                    mycolors.WARNING,
-                )
-                time.sleep(1)
-                continue
+
+            # Check for any errors in response
             try:
                 data = json.loads(response.text)
             except json.JSONDecodeError:
@@ -264,6 +257,17 @@ def get_inventory(user_id):
                     logging.warning("Failed to load inventory: %s", err["message"])
 
                 raise FailedToLoadInventoryException
+
+            # Check for response
+            if response.status_code != 200:
+                log(
+                    f"Inventory request failed with status {
+                        response.status_code
+                    }. Attempt {attempt + 1}/{MAX_RETRIES}.",
+                    mycolors.WARNING,
+                )
+                time.sleep(1)
+                continue
 
             if response.status_code == 200:
                 break
@@ -1253,9 +1257,13 @@ def search_for_trades(user_id, guarantee_trade=False):
 
     if len(my_inventory) == 0:
         log(
-            "There are no tradable items or they have all been filtered out.",
-            mycolors.WARNING,
+            "You dont have enough tradable items or they have all been filtered out by maximum_xv1, retrying in 30 minutes...",
+            mycolors.FAIL,
         )
+        cooldowns.items_on_hold_event.set()
+        time.sleep(1800)
+        cooldowns.items_on_hold_event.clear()
+
         return
 
     try:

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -137,61 +137,74 @@ def get_xsrf():
 
 def add_extra_info(item):
     # Statement for item info of v1 APIs (Inventory API)
-    if "buildersClubMembershipType" in item:
-        item_name_encoded = item["name"].encode("utf-8")
-        item["Name"] = item_name_encoded  # For compatibility
-        item["name"] = item_name_encoded
-        item["itemId"] = int(item["assetId"])
+    try:
+        if "buildersClubMembershipType" in item:
+            item_name_encoded = item["name"].encode("utf-8")
+            item["Name"] = item_name_encoded  # For compatibility
+            item["name"] = item_name_encoded
+            item["itemId"] = int(item["assetId"])
 
-        item["ImageLink"] = (
-            "https://www.roblox.com/asset-thumbnail/image?assetId=%i&height=110&width=110"
-            % (item["assetId"])
-        )
-        item["ItemLink"] = "https://www.roblox.com/catalog/%i/--" % item["assetId"]
-        item["SerialNumber"] = item["serialNumber"]
-        item["SerialNumberTotal"] = item[
-            "assetStock"
-        ]  # I think this is correct but not entirely sure
-        item["OriginalPrice"] = item["originalPrice"]
-        item["userAssetID"] = item["assetId"]
-        item["UserAssetID"] = item["assetId"]
+            item["ImageLink"] = (
+                "https://www.roblox.com/asset-thumbnail/image?assetId=%i&height=110&width=110"
+                % (item["assetId"])
+            )
+            item["ItemLink"] = "https://www.roblox.com/catalog/%i/--" % item["assetId"]
+            item["SerialNumber"] = item["serialNumber"]
+            item["SerialNumberTotal"] = item[
+                "assetStock"
+            ]  # I think this is correct but not entirely sure
+            item["OriginalPrice"] = item["originalPrice"]
+            item["userAssetID"] = item["assetId"]
+            item["UserAssetID"] = item["assetId"]
 
-        membership_type = (
-            item["buildersClubMembershipType"]
-            if "buildersClubMembershipType" in item
-            else item["membershipType"]
-        )
-        item["buildersClubMembershipType"] = membership_type
-        item["MembershipLevel"] = membership_type
-        item["AveragePrice"] = int(item["recentAveragePrice"])
+            membership_type = (
+                item["buildersClubMembershipType"]
+                if "buildersClubMembershipType" in item
+                else item["membershipType"]
+            )
+            item["buildersClubMembershipType"] = membership_type
+            item["MembershipLevel"] = membership_type
+            item["AveragePrice"] = int(item["recentAveragePrice"])
 
-    # Statement for the v2 APIs
-    else:
-        item_name_encoded = item["itemName"].encode("utf-8")
-        item["name"] = item_name_encoded
-        item["Name"] = item_name_encoded
-        item["itemId"] = int(item["itemTarget"]["targetId"])
-        item["AveragePrice"] = int(item["recentAveragePrice"])
-
-        # This is a replacement to item_id for bundles
-        collectable_id = item.get("collectibleItemId")
-        item["collectibleItemId"] = collectable_id
-
-        item_instance_id = item.get("itemInstanceId")
-
-        # Add instance Id if its from the trade inventory API
-        item_instances = item.get("instances")
-        if item_instance_id:
-            item["collectibleItemInstanceId"] = item_instance_id
+        # Statement for the v2 APIs
         else:
-            if item_instances:
-                item_instance_id = item_instances[0]["collectibleItemInstanceId"]
-                item["collectibleItemInstanceId"] = item_instance_id
-        if item_instances:
-            item["isOnHold"] = item_instances[0]["isOnHold"]
+            item_name_encoded = item["itemName"].encode("utf-8")
+            item["name"] = item_name_encoded
+            item["Name"] = item_name_encoded
+            item["itemId"] = int(item["itemTarget"]["targetId"])
+            item["AveragePrice"] = int(item["recentAveragePrice"])
 
-        item["userAssetId"] = item_instance_id
-        item["itemType"] = item["itemTarget"]["itemType"]
+            # This is a replacement to item_id for bundles
+            collectable_id = item.get("collectibleItemId")
+            item["collectibleItemId"] = collectable_id
+
+            item_instance_id = item.get("itemInstanceId")
+
+            # Add instance Id if its from the trade inventory API
+            item_instances = item.get("instances")
+            if item_instance_id:
+                item["collectibleItemInstanceId"] = item_instance_id
+            else:
+                if item_instances:
+                    item_instance_id = item_instances[0]["collectibleItemInstanceId"]
+                    item["collectibleItemInstanceId"] = item_instance_id
+            if item_instances:
+                item["isOnHold"] = item_instances[0]["isOnHold"]
+
+            item["userAssetId"] = item_instance_id
+            item["itemType"] = item["itemTarget"]["itemType"]
+    except KeyError as e:
+        log(f"malformed response - missing expected field: {e}", mycolors.FAIL)
+        log(f"problematic item: {item}", mycolors.FAIL)
+        raise
+    except (ValueError, TypeError) as e:
+        log(f"malformed response - type conversion error: {e}")
+        log(f"problematic item: {item}", mycolors.FAIL)
+        raise
+    except Exception as e:
+        log(f"unexpected error processing response: {e}", mycolors.FAIL)
+        log(f"problematic item: {item}", mycolors.FAIL)
+        raise
 
     item_data = valuemanager.get_value(item)
 
@@ -274,7 +287,10 @@ def get_inventory(user_id):
 
     inventory = []
     for item in inventory_raw:
-        new_item = add_extra_info(item)
+        try:
+            new_item = add_extra_info(item)
+        except Exception as e:
+            log(f"skipping item from fetching inventory")
         if new_item is None:
             continue
         # Only do this for our inventory
@@ -290,7 +306,7 @@ def get_inventory(user_id):
         item
         for item in inventory
         if item["value"] <= int(settings["Trading"]["maximum_item_value"])
-        and not item.get("isOnHold", True)
+        and not item["isOnHold"]
     ]
     return inventory
 
@@ -715,17 +731,21 @@ def listen_for_inbound_trades():
                     logging.warning(f"no self_user id in {trade_data}")
                     continue
 
-                my_items = [
-                    info
-                    for item in my_offer["items"]
-                    if (info := add_extra_info(item)) is not None
-                ]
+                try:
+                    my_items = [
+                        info
+                        for item in my_offer["items"]
+                        if (info := add_extra_info(item)) is not None
+                    ]
 
-                their_items = [
-                    info
-                    for item in their_offer["items"]
-                    if (info := add_extra_info(item)) is not None
-                ]
+                    their_items = [
+                        info
+                        for item in their_offer["items"]
+                        if (info := add_extra_info(item)) is not None
+                    ]
+                except Exception as e:
+                    log(f"failed to add item data to inbound trade", mycolors.FAIL)
+                    continue
 
                 my_items_original = copy.deepcopy(my_items)
                 their_items_original = copy.deepcopy(their_items)

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -227,18 +227,13 @@ def get_inventory(user_id):
     MAX_RETRIES = 5
     cursor = ""
     while cursor is not None:
-        url = (
-            f"https://trades.roblox.com/v2/users/{user_id}"
-            f"/tradableItems?sortBy=CreationTime&sortOrder=2&limit=50&cursor={cursor}"
-        )
+        url = f"https://trades.roblox.com/v2/users/{user_id}/tradableItems?sortBy=CreationTime&sortOrder=2&limit=50&cursor={cursor}"
 
         for attempt in range(MAX_RETRIES):
             response = session.get(url)
             if response.status_code == 429:
                 log(
-                    f"Loading inventory throttled. Attempt {attempt + 1}/{
-                        MAX_RETRIES
-                    }.",
+                    f"Loading inventory throttled. Attempt {attempt + 1}/{MAX_RETRIES}.",
                     mycolors.WARNING,
                 )
                 time.sleep(10)
@@ -260,9 +255,7 @@ def get_inventory(user_id):
             # Check for response
             if response.status_code != 200:
                 log(
-                    f"Inventory request failed with status {
-                        response.status_code
-                    }. Attempt {attempt + 1}/{MAX_RETRIES}.",
+                    f"Inventory request failed with status {response.status_code}. Attempt {attempt + 1}/{MAX_RETRIES}.",
                     mycolors.WARNING,
                 )
                 time.sleep(1)
@@ -553,9 +546,7 @@ def send_trade(
                 ):
                     cooldowns.items_on_hold_event.set()
                     log(
-                        f"{
-                            session.cookies['username']
-                        } has hit the daily 100 trade limit waiting 3 hours, then retrying",
+                        f"{session.cookies['username']} has hit the daily 100 trade limit waiting 3 hours, then retrying",
                         mycolors.WARNING,
                         post_to_webhook=True,
                     )
@@ -690,16 +681,17 @@ def listen_for_inbound_trades():
             for tradeInfo in inbound:
                 trade_data = pull_trade(tradeInfo["id"])
 
-                my_offer = None
-                their_offer = None
-
-                try:
-                    my_offer = copy.deepcopy(trade_data["participantAOffer"])
-                    their_offer = copy.deepcopy(trade_data["participantBOffer"])
-                except:
-                    assert my_offer is not None
-                    assert their_offer is not None
+                if (
+                    "participantAOffer" not in trade_data
+                    or "participantBOffer" not in trade_data
+                ):
+                    logging.warning(
+                        "trade_data missing participantAOffer or participantBOffer, skipping trade."
+                    )
                     continue
+
+                my_offer = copy.deepcopy(trade_data["participantAOffer"])
+                their_offer = copy.deepcopy(trade_data["participantBOffer"])
 
                 my_items = [
                     info
@@ -1139,7 +1131,7 @@ def search_for_trades(user_id, guarantee_trade=False):
     #
     # Add ratelimit throttle to prevent spamming this API
     global can_trade_throttle, can_trade_timestamp, can_trade_backoff
-    if can_trade_throttle and time.time() - can_trade_timestamp < 30:
+    if can_trade_throttle and time.time() - can_trade_timestamp < can_trade_backoff:
         # Still throttled, skip the request and assume we can trade
         pass
     else:

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -600,12 +600,11 @@ def send_trade(
                             cooldowns.items_on_hold_event.clear()
                             break
                     except FailedToLoadInventoryException:
-                        logging.exception("Caught exception while getting my_inventory")
-
                         log(
                             "Failed to load inventory while checking on-hold.",
                             mycolors.WARNING,
                         )
+                        logging.exception("Caught exception while getting my_inventory")
 
                     log(
                         "All items on hold, waiting 30 minutes, then refreshing...",
@@ -1174,14 +1173,15 @@ def search_for_trades(user_id, guarantee_trade=False):
     except FailedToLoadInventoryException:
         log("Failed to load own inventory.", mycolors.FAIL)
         logging.exception("Caught exception while getting my_inventory")
-
         return
     try:
         their_inventory = get_inventory(user_id)
     except FailedToLoadInventoryException:
-        logging.exception("Caught exception while getting my_inventory")
-
-        logging.warning("Skipping user...")
+        log(
+            f"Skipping getting inventory for user {user_id}",
+            mycolors.WARNING,
+        )
+        logging.exception("Caught exception while getting their inventory")
         return
 
     def highest_value_affordable(inventory, upper_limit_multiplier):

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -680,6 +680,7 @@ def listen_for_inbound_trades():
             good_trades = []
 
             max_handle_value = int(settings["Trading"]["ignore_inbound_above_value"])
+            session_user_id = str(session.cookies.get("user_id"))
 
             for tradeInfo in inbound:
                 trade_data = pull_trade(tradeInfo["id"])
@@ -693,8 +694,26 @@ def listen_for_inbound_trades():
                     )
                     continue
 
-                my_offer = copy.deepcopy(trade_data["participantAOffer"])
-                their_offer = copy.deepcopy(trade_data["participantBOffer"])
+                participant_a_user_id = str(
+                    trade_data["participantAOffer"]["user"]["id"]
+                )
+                participant_b_user_id = str(
+                    trade_data["participantBOffer"]["user"]["id"]
+                )
+
+                if participant_a_user_id == session_user_id:
+                    my_offer = copy.deepcopy(trade_data["participantAOffer"])
+                    their_offer = copy.deepcopy(trade_data["participantBOffer"])
+                elif participant_b_user_id == session_user_id:
+                    my_offer = copy.deepcopy(trade_data["participantBOffer"])
+                    their_offer = copy.deepcopy(trade_data["participantAOffer"])
+                else:
+                    log(
+                        f"couldn't find my user_id in trade information for inbound trade. check logs for details...",
+                        mycolors.WARNING,
+                    )
+                    logging.warning(f"no self_user id in {trade_data}")
+                    continue
 
                 my_items = [
                     info

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -231,7 +231,9 @@ def get_inventory(user_id):
 
         for attempt in range(MAX_RETRIES):
             response = session.get(url)
-            if response.status_code == 429:
+            if response.status_code == 200:
+                break
+            elif response.status_code == 429:
                 log(
                     f"Loading inventory throttled. Attempt {attempt + 1}/{MAX_RETRIES}.",
                     mycolors.WARNING,
@@ -242,7 +244,6 @@ def get_inventory(user_id):
             # Check for any errors in response
             try:
                 data = json.loads(response.text)
-
                 if "errors" in data:
                     for err in data["errors"]:
                         logging.warning("Failed to load inventory: %s", err["message"])
@@ -251,7 +252,7 @@ def get_inventory(user_id):
                 logging.warning(
                     "Failed to parse inventory JSON on attempt %d", attempt + 1
                 )
-
+                continue
             # Check for response
             if response.status_code != 200:
                 log(
@@ -260,15 +261,17 @@ def get_inventory(user_id):
                 )
                 time.sleep(1)
                 continue
-
-            if response.status_code == 200:
-                break
         else:
             log("Failed to load inventory after all retries.", mycolors.FAIL)
             raise FailedToLoadInventoryException
 
-        cursor = data["nextPageCursor"]
-        inventory_raw += data["items"]
+        try:
+            cursor = data["nextPageCursor"]
+            inventory_raw += data["items"]
+        except Exception:
+            log("Failed to items from inventory response", mycolors.FAIL)
+            raise FailedToLoadInventoryException
+
     inventory = []
     for item in inventory_raw:
         new_item = add_extra_info(item)
@@ -536,7 +539,7 @@ def send_trade(
             errors = data["errors"]
             error_output_text = " ".join([error["message"] for error in errors])
         else:
-            error_output_text = data
+            error_output_text = json.dumps(data)
 
         if response.status_code == 429:
             if "errors" in response.json():

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -181,13 +181,15 @@ def add_extra_info(item):
         item_instance_id = item.get("ItemInstanceId")
 
         # Add instance Id if its from the trade inventory API
+        item_instances = item.get("instances")
         if item_instance_id:
             item["collectibleItemInstanceId"] = item_instance_id
         else:
-            item_instances = item.get("instances")
             if item_instances:
                 item_instance_id = item_instances[0]["collectibleItemInstanceId"]
                 item["collectibleItemInstanceId"] = item_instance_id
+        if item_instances:
+            item["isOnHold"] = item_instances[0]["isOnHold"]
 
         item["userAssetId"] = item_instance_id
         item["itemType"] = item["itemTarget"]["itemType"]
@@ -249,7 +251,6 @@ def get_inventory(user_id):
                 log("Inventory request failed. Trying again.", mycolors.WARNING)
                 time.sleep(1)
                 continue
-
             if response.status_code == 429:
                 log("Loading Inventory throttled retrying.", mycolors.WARNING)
                 time.sleep(10)
@@ -261,6 +262,8 @@ def get_inventory(user_id):
             if "errors" in data:
                 for err in data["errors"]:
                     logging.warning("Failed to load inventory: %s" % (err["message"]))
+                raise FailedToLoadInventoryException
+            if response.status_code == 500:
                 raise FailedToLoadInventoryException
 
             break
@@ -287,6 +290,8 @@ def get_inventory(user_id):
         item
         for item in inventory
         if item["value"] <= int(settings["Trading"]["maximum_item_value"])
+        # Assume item is on hold if it errored to get isOnHold
+        and not item.get("isOnHold", True)
     ]
 
     return inventory

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -177,7 +177,7 @@ def add_extra_info(item):
         collectable_id = item.get("collectibleItemId")
         item["collectibleItemId"] = collectable_id
 
-        item_instance_id = item.get("ItemInstanceId")
+        item_instance_id = item.get("itemInstanceId")
 
         # Add instance Id if its from the trade inventory API
         item_instances = item.get("instances")

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -222,55 +222,57 @@ class AllSelfItemsHoldException(Exception):
 @cached(cache=TTLCache(maxsize=4096, ttl=300))
 def get_inventory(user_id):
     user_id = int(user_id)
-
     inventory_raw = []
 
-    # NOTE: I don't like the original approach because you get ratelimited every user you scan -Flaried
-
-    # Good job tardblox, now I get to send EVEN MORE http requests to your server :DDDDD
-    # Wasting resources is fun! 8x more to be exact :-)
-    # accessory_asset_type_ids = [8, 41, 42, 43, 44, 45, 46, 47]
-    # other_asset_type_ids = [19, 18]
-    # asset_type_ids = (accessory_asset_type_ids + other_asset_type_ids
-    #                   if settings["Trading"]["only_trade_accessories"] != "true"
-    #                   else accessory_asset_type_ids[:])
-
+    MAX_RETRIES = 5
     cursor = ""
-    while cursor is not None:  # Continue until we've loaded all of this asset type
-        data = None
+    while cursor is not None:
+        url = (
+            f"https://trades.roblox.com/v2/users/{user_id}"
+            f"/tradableItems?sortBy=CreationTime&sortOrder=2&limit=50&cursor={cursor}"
+        )
 
-        for i in range(5):  # Up to 5 attempts
-            # NOTE: limit is 50 because 100 causes internal server error for big inventories
-            url = f"https://trades.roblox.com/v2/users/{user_id}/tradableItems?sortBy=CreationTime&sortOrder=2&limit=50&cursor={cursor}"
-
+        for attempt in range(MAX_RETRIES):
             response = session.get(url)
-
-            data = json.loads(response.text)
-
-            if response.status_code == 503:
-                log("Inventory request failed. Trying again.", mycolors.WARNING)
+            if response.status_code == 429:
+                log(
+                    f"Loading inventory throttled. Attempt {attempt + 1}/{
+                        MAX_RETRIES
+                    }.",
+                    mycolors.WARNING,
+                )
+                time.sleep(10)
+                continue
+            if response.status_code != 200:
+                log(
+                    f"Inventory request failed with status {
+                        response.status_code
+                    }. Attempt {attempt + 1}/{MAX_RETRIES}.",
+                    mycolors.WARNING,
+                )
                 time.sleep(1)
                 continue
-            if response.status_code == 429:
-                log("Loading Inventory throttled retrying.", mycolors.WARNING)
-                time.sleep(10)
-                if i >= 5:
-                    log("Failed to load inventory. Exiting.", mycolors.FAIL)
-                    sys.exit(0)
+            try:
+                data = json.loads(response.text)
+            except json.JSONDecodeError:
+                logging.warning(
+                    "Failed to parse inventory JSON on attempt %d", attempt + 1
+                )
                 continue
-
             if "errors" in data:
                 for err in data["errors"]:
-                    logging.warning("Failed to load inventory: %s" % (err["message"]))
-                raise FailedToLoadInventoryException
-            if response.status_code == 500:
+                    logging.warning("Failed to load inventory: %s", err["message"])
+
                 raise FailedToLoadInventoryException
 
-            break
+            if response.status_code == 200:
+                break
+        else:
+            log("Failed to load inventory after all retries.", mycolors.FAIL)
+            raise FailedToLoadInventoryException
 
         cursor = data["nextPageCursor"]
         inventory_raw += data["items"]
-
     inventory = []
     for item in inventory_raw:
         new_item = add_extra_info(item)
@@ -284,16 +286,13 @@ def get_inventory(user_id):
             if new_item["AveragePrice"] > new_item["value"]:
                 new_item["value"] = new_item["AveragePrice"]
         inventory.append(new_item)
-
     inventory = [item for item in inventory if item["value"] > 0]
     inventory = [
         item
         for item in inventory
         if item["value"] <= int(settings["Trading"]["maximum_item_value"])
-        # Assume item is on hold if it errored to get isOnHold
         and not item.get("isOnHold", True)
     ]
-
     return inventory
 
 
@@ -303,7 +302,17 @@ def sale_manager():
 
     while True:
         try:
-            my_inventory = get_inventory(session.cookies["user_id"])
+            try:
+                my_inventory = get_inventory(session.cookies["user_id"])
+            except FailedToLoadInventoryException:
+                log("Failed to load self inventory. Retrying...", mycolors.FAIL)
+                logging.exception("Caught exception while getting my_inventory")
+
+                time.sleep(
+                    float(settings["Trading"]["interval_between_placing_items_on_sale"])
+                )
+                continue
+
             filtered_inventory = []
             for item in my_inventory:
                 if (
@@ -541,7 +550,9 @@ def send_trade(
                 ):
                     cooldowns.items_on_hold_event.set()
                     log(
-                        f"{session.cookies['username']} has hit the daily 100 trade limit waiting 3 hours, then retrying",
+                        f"{
+                            session.cookies['username']
+                        } has hit the daily 100 trade limit waiting 3 hours, then retrying",
                         mycolors.WARNING,
                         post_to_webhook=True,
                     )
@@ -578,11 +589,20 @@ def send_trade(
                 cooldowns.items_on_hold_event.set()
 
                 while True:
-                    remove_trades_with_invalid_items_from_queue()
-                    if len(get_inventory(session.cookies["user_id"])) > 0:
-                        # stop the on_hold event
-                        cooldowns.items_on_hold_event.clear()
-                        break
+                    try:
+                        remove_trades_with_invalid_items_from_queue()
+                        if len(get_inventory(session.cookies["user_id"])) > 0:
+                            # stop the on_hold event
+                            cooldowns.items_on_hold_event.clear()
+                            break
+                    except FailedToLoadInventoryException:
+                        logging.exception("Caught exception while getting my_inventory")
+
+                        log(
+                            "Failed to load inventory while checking on-hold.",
+                            mycolors.WARNING,
+                        )
+
                     log(
                         "All items on hold, waiting 30 minutes, then refreshing...",
                         post_to_webhook=True,
@@ -1014,7 +1034,8 @@ def update_score_threshold():
             except ZeroDivisionError:
                 return
 
-        clamp = lambda x: max(x, 0.001)
+        def clamp(x):
+            return max(x, 0.001)
 
         try:
             percent_diff = abs(
@@ -1144,11 +1165,18 @@ def search_for_trades(user_id, guarantee_trade=False):
             pass
         return
 
-    my_inventory = get_inventory(session.cookies["user_id"])
+    try:
+        my_inventory = get_inventory(session.cookies["user_id"])
+    except FailedToLoadInventoryException:
+        log("Failed to load own inventory.", mycolors.FAIL)
+        logging.exception("Caught exception while getting my_inventory")
 
+        return
     try:
         their_inventory = get_inventory(user_id)
     except FailedToLoadInventoryException:
+        logging.exception("Caught exception while getting my_inventory")
+
         logging.warning("Skipping user...")
         return
 
@@ -1266,9 +1294,9 @@ def search_for_trades(user_id, guarantee_trade=False):
                 yield x, y
 
     my_combos = combos(len(my_inventory), int(settings["Trading"]["maximum_xv1"]))
-    their_combos_wrapper = lambda: combos(
-        len(their_inventory), int(settings["Trading"]["maximum_1vx"])
-    )
+
+    def their_combos_wrapper():
+        return combos(len(their_inventory), int(settings["Trading"]["maximum_1vx"]))
 
     combinations = prod(my_combos, their_combos_wrapper)
 

--- a/otb-legacy-source/trading.py
+++ b/otb-legacy-source/trading.py
@@ -709,7 +709,7 @@ def listen_for_inbound_trades():
                     their_offer = copy.deepcopy(trade_data["participantAOffer"])
                 else:
                     log(
-                        f"couldn't find my user_id in trade information for inbound trade. check logs for details...",
+                        "couldn't find my user_id in trade information for inbound trade. check logs for details...",
                         mycolors.WARNING,
                     )
                     logging.warning(f"no self_user id in {trade_data}")

--- a/otb-legacy-source/tradingbot.py
+++ b/otb-legacy-source/tradingbot.py
@@ -313,8 +313,9 @@ def find_people():
                     break
                 if response.status_code != 200:
                     # Something went wrong with this item. Skip it.
-                    logging.warning(
-                        f"Roblox had internal server error while fetching item owners. item_id: {item_id} item: {item} status_code {response.status_code}"
+                    log(
+                        f"Roblox had internal server error while fetching item owners. item_id: {item_id} item: {item} status_code {response.status_code}",
+                        mycolors.FAIL,
                     )
                     break
                 item_owners = [

--- a/otb-legacy-source/tradingbot.py
+++ b/otb-legacy-source/tradingbot.py
@@ -16,7 +16,7 @@ from settings import settings
 #################################################
 RELEASE = True
 
-VERSION = 57
+VERSION = 58
 #################################################
 
 if RELEASE:

--- a/otb-legacy-source/tradingbot.py
+++ b/otb-legacy-source/tradingbot.py
@@ -314,10 +314,13 @@ def find_people():
                 if response.status_code != 200:
                     # Something went wrong with this item. Skip it.
                     log(
-                        f"Roblox had internal server error while fetching item owners. item_id: {item_id} item: {item} status_code {response.status_code}",
-                        mycolors.FAIL,
+                        f"Skipping getting owners for {item_id}",
+                        mycolors.WARNING,
                     )
-                    break
+                    logging.warning(
+                        f"Roblox had internal server error while fetching item owners. item: {item} status_code {response.status_code}"
+                    )
+                    continue
                 item_owners = [
                     item["owner"]["id"]
                     for item in json.loads(response.text)["data"]

--- a/otb-legacy-source/tradingbot.py
+++ b/otb-legacy-source/tradingbot.py
@@ -263,9 +263,10 @@ def find_people():
                 f.write(str(cursor))
 
             for item in decoded_response["data"]:
-                item_id = item["collectibleItemId"]
+                collectible_item_id = item["collectibleItemId"]
+                item_id = item["id"]
                 response = session.get(
-                    f"https://apis.roblox.com/marketplace-sales/v1/item/{item_id}/resellers?cursor=&limit=100"
+                    f"https://apis.roblox.com/marketplace-sales/v1/item/{collectible_item_id}/resellers?cursor=&limit=100"
                 )
                 if response.status_code == 429:
                     log("ratelimited trying to get resellers")
@@ -313,7 +314,7 @@ def find_people():
                 if response.status_code != 200:
                     # Something went wrong with this item. Skip it.
                     logging.warning(
-                        f"Roblox had internal server error while fetching item owners. item: {item_id} status_code {response.status_code}"
+                        f"Roblox had internal server error while fetching item owners. item_id: {item_id} item: {item} status_code {response.status_code}"
                     )
                     break
                 item_owners = [

--- a/otb-legacy-source/tradingbot.py
+++ b/otb-legacy-source/tradingbot.py
@@ -268,7 +268,7 @@ def find_people():
                     f"https://apis.roblox.com/marketplace-sales/v1/item/{item_id}/resellers?cursor=&limit=100"
                 )
                 if response.status_code == 429:
-                    print("ratelimited trying to get resellers")
+                    log("ratelimited trying to get resellers")
                 else:
                     decoded_json = json.loads(response.text)
 
@@ -494,14 +494,8 @@ if settings["Debugging"]["memory_debugging"] == "true":
         import valuemanager
 
         while True:
-            print(
-                "ID queue bytes: %i, Type values: %i, Values: %i, Trade queue: %i"
-                % (
-                    sys.getsizeof(queueIds),
-                    sys.getsizeof(typevalues.typeValues),
-                    sys.getsizeof(valuemanager.values),
-                    sys.getsizeof(trading.tradeSendQueue),
-                )
+            log(
+                f"ID queue bytes: {sys.getsizeof(queueIds)} Type values: {sys.getsizeof(typevalues.typeValues)} Values: {sys.getsizeof(valuemanager.values)}  Trade queue: {sys.getsizeof(trading.tradeSendQueue)}"
             )
             time.sleep(5)
 

--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -166,7 +166,7 @@ def generate_value(item):
             break
         if response.status_code == 429:
             log(
-                "Got too many requests on resale-data, Waiting 15s and trying again.",
+                f"Got too many requests on resale-data, Waiting {retry_delay} and trying again.",
                 mycolors.WARNING,
             )
             time.sleep(retry_delay)

--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -114,9 +114,7 @@ def generate_value(item):
         log(f"{item_name} uses collectible item id", mycolors.WARNING)
         while True:
             item_type_param = f"?itemType={itemType}" if itemType else "?itemType=Asset"
-            item_details_api = f"https://catalog.roblox.com/v1/catalog/items/{
-                asset_id
-            }/details{item_type_param}"
+            item_details_api = f"https://catalog.roblox.com/v1/catalog/items/{asset_id}/details{item_type_param}"
 
             item_details = session.get(item_details_api)
             if item_details.status_code == 429:

--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -114,7 +114,9 @@ def generate_value(item):
         log(f"{item_name} uses collectible item id", mycolors.WARNING)
         while True:
             item_type_param = f"?itemType={itemType}" if itemType else "?itemType=Asset"
-            item_details_api = f"https://catalog.roblox.com/v1/catalog/items/{asset_id}/details{item_type_param}"
+            item_details_api = f"https://catalog.roblox.com/v1/catalog/items/{
+                asset_id
+            }/details{item_type_param}"
 
             item_details = session.get(item_details_api)
             if item_details.status_code == 429:
@@ -125,7 +127,9 @@ def generate_value(item):
                 time.sleep(15)
             if item_details.status_code != 200:
                 log(
-                    f"Failed to load item details. Continuing. {item_details.text} item_id: {asset_id} url: {item_details_api}",
+                    f"Failed to load item details. Continuing. {
+                        item_details.text
+                    } item_id: {asset_id} url: {item_details_api}",
                     mycolors.FAIL,
                 )
                 return
@@ -136,14 +140,19 @@ def generate_value(item):
             return
 
     if collectibleItemId:
-        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectibleItemId}/resale-data"
+        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{
+            collectibleItemId
+        }/resale-data"
     # Bundles (Faces) are always going to use the new API and asset collectibleItemId to see resale data.
     elif collectibleItemInstanceId and itemType == "Bundle":
         collectable_id = get_collectible_id_from_asset(item_id)
-        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectable_id}/resale-data"
+        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{
+            collectable_id
+        }/resale-data"
     else:
         resale_id = item_id
 
+    retry_delay = 15
     while True:
         # NOTE: Assume the URL is the v1 API (all older items)
         if url is None:
@@ -160,19 +169,24 @@ def generate_value(item):
                 "Got too many requests on resale-data, Waiting 15s and trying again.",
                 mycolors.WARNING,
             )
-            time.sleep(15)
+            time.sleep(retry_delay)
+            retry_delay = min(retry_delay * 2, 120)
             continue
         # NOTE: Handle new items that use the v2 API
         elif response.status_code == 400 or response.status_code == 404:
             collectable_id = get_collectible_id_from_asset(item_id)
             if collectable_id:
-                url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectable_id}/resale-data"
+                url = f"https://apis.roblox.com/marketplace-sales/v1/item/{
+                    collectable_id
+                }/resale-data"
             else:
                 log(f"couldn't resolve status 400 for {item}")
                 return
         else:
             log(
-                f"unxepected response for resolving collectable_id {response.text} : {response.status_code} : {response.url}"
+                f"unxepected response for resolving collectable_id {response.text} : {
+                    response.status_code
+                } : {response.url}"
             )
             return
 

--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -148,6 +148,7 @@ def generate_value(item):
         resale_id = item_id
 
     retry_delay = 15
+    tried_v2_fallback = False
     while True:
         # NOTE: Assume the URL is the v1 API (all older items)
         if url is None:
@@ -166,7 +167,9 @@ def generate_value(item):
             retry_delay = min(retry_delay * 2, 120)
             continue
         # NOTE: Handle new items that use the v2 API
-        elif response.status_code == 400 or response.status_code == 404:
+        elif response.status_code in (400, 404) and not tried_v2_fallback:
+            tried_v2_fallback = True
+
             collectable_id = get_collectible_id_from_asset(item_id)
             if collectable_id:
                 url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectable_id}/resale-data"

--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -125,11 +125,11 @@ def generate_value(item):
                     mycolors.WARNING,
                 )
                 time.sleep(15)
+                continue
+
             if item_details.status_code != 200:
                 log(
-                    f"Failed to load item details. Continuing. {
-                        item_details.text
-                    } item_id: {asset_id} url: {item_details_api}",
+                    f"Failed to load item details. Continuing. {item_details.text} item_id: {asset_id} url: {item_details_api}",
                     mycolors.FAIL,
                 )
                 return
@@ -140,15 +140,12 @@ def generate_value(item):
             return
 
     if collectibleItemId:
-        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{
-            collectibleItemId
-        }/resale-data"
+        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectibleItemId}/resale-data"
     # Bundles (Faces) are always going to use the new API and asset collectibleItemId to see resale data.
     elif collectibleItemInstanceId and itemType == "Bundle":
         collectable_id = get_collectible_id_from_asset(item_id)
-        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{
-            collectable_id
-        }/resale-data"
+        if collectable_id:
+            url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectable_id}/resale-data"
     else:
         resale_id = item_id
 
@@ -156,9 +153,7 @@ def generate_value(item):
     while True:
         # NOTE: Assume the URL is the v1 API (all older items)
         if url is None:
-            url = (
-                f"https://economy.roblox.com/v1/assets/v1/item/{resale_id}/resale-data"
-            )
+            url = f"https://economy.roblox.com/v1/assets/{resale_id}/resale-data"
 
         response = session.get(url)
         if response.status_code == 200:
@@ -176,17 +171,13 @@ def generate_value(item):
         elif response.status_code == 400 or response.status_code == 404:
             collectable_id = get_collectible_id_from_asset(item_id)
             if collectable_id:
-                url = f"https://apis.roblox.com/marketplace-sales/v1/item/{
-                    collectable_id
-                }/resale-data"
+                url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectable_id}/resale-data"
             else:
                 log(f"couldn't resolve status 400 for {item}")
                 return
         else:
             log(
-                f"unxepected response for resolving collectable_id {response.text} : {
-                    response.status_code
-                } : {response.url}"
+                f"unexpected response for resolving collectable_id {response.text} : {response.status_code} : {response.url}"
             )
             return
 

--- a/otb-legacy-source/valuemanager.py
+++ b/otb-legacy-source/valuemanager.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import sys
 import json
 import time
 import mycolors
@@ -95,20 +94,67 @@ def parse_date(date_str):
     return None
 
 
-def generate_value(item_id):
-    log("Generating value for %i..." % item_id)
+def generate_value(item):
+    item_name = item["name"]
+    log(f"Generating value for {item_name}...")
 
     decoded = None
 
     # NOTE: these are set so we can use both V1 and V2 APIs without changing item id or url
     url = None
-    resale_id = item_id
+    resale_id = None
+
+    item_id = item["itemId"]
+    collectibleItemInstanceId = item.get("collectibleItemInstanceId")
+    collectibleItemId = item.get("collectibleItemId")
+
+    itemType = item.get("itemType", "Asset")
+
+    def get_collectible_id_from_asset(asset_id):
+        log(f"{item_name} uses collectible item id", mycolors.WARNING)
+        while True:
+            item_type_param = f"?itemType={itemType}" if itemType else "?itemType=Asset"
+            item_details_api = f"https://catalog.roblox.com/v1/catalog/items/{asset_id}/details{item_type_param}"
+
+            item_details = session.get(item_details_api)
+            if item_details.status_code == 429:
+                log(
+                    "Got too many on item details requests. Waiting 15s and trying again.",
+                    mycolors.WARNING,
+                )
+                time.sleep(15)
+            if item_details.status_code != 200:
+                log(
+                    f"Failed to load item details. Continuing. {item_details.text} item_id: {asset_id} url: {item_details_api}",
+                    mycolors.FAIL,
+                )
+                return
+            detail_data = item_details.json()
+            if "collectibleItemId" in detail_data:
+                return detail_data["collectibleItemId"]
+
+            return
+
+    if collectibleItemId:
+        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectibleItemId}/resale-data"
+    # Bundles (Faces) are always going to use the new API and asset collectibleItemId to see resale data.
+    elif collectibleItemInstanceId and itemType == "Bundle":
+        collectable_id = get_collectible_id_from_asset(item_id)
+        url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectable_id}/resale-data"
+    else:
+        resale_id = item_id
+
     while True:
         # NOTE: Assume the URL is the v1 API (all older items)
         if url is None:
-            url = f"https://economy.roblox.com/v1/assets/{resale_id}/resale-data"
+            url = (
+                f"https://economy.roblox.com/v1/assets/v1/item/{resale_id}/resale-data"
+            )
 
         response = session.get(url)
+        if response.status_code == 200:
+            decoded = json.loads(response.text)
+            break
         if response.status_code == 429:
             log(
                 "Got too many requests on resale-data, Waiting 15s and trying again.",
@@ -117,33 +163,18 @@ def generate_value(item_id):
             time.sleep(15)
             continue
         # NOTE: Handle new items that use the v2 API
-        elif response.status_code == 400:
-            log("Item uses new API retrying..", mycolors.WARNING)
-            item_details = session.get(
-                f"https://catalog.roblox.com/v1/catalog/items/{item_id}/details?itemType=asset"
+        elif response.status_code == 400 or response.status_code == 404:
+            collectable_id = get_collectible_id_from_asset(item_id)
+            if collectable_id:
+                url = f"https://apis.roblox.com/marketplace-sales/v1/item/{collectable_id}/resale-data"
+            else:
+                log(f"couldn't resolve status 400 for {item}")
+                return
+        else:
+            log(
+                f"unxepected response for resolving collectable_id {response.text} : {response.status_code} : {response.url}"
             )
-            if item_details.status_code == 429:
-                log(
-                    "Got too many on item details requests. Waiting 15s and trying again.",
-                    mycolors.WARNING,
-                )
-                time.sleep(15)
-                continue
-
-            if item_details.status_code != 200:
-                print(item_details.status_code)
-                log("Failed to load item details. Exiting.", mycolors.FAIL)
-                sys.exit(0)
-
-            detail_data = item_details.json()
-            if "collectibleItemId" in detail_data:
-                resale_id = detail_data["collectibleItemId"]
-                url = f"https://apis.roblox.com/marketplace-sales/v1/item/{resale_id}/resale-data"
-
-            continue
-
-        decoded = json.loads(response.text)
-        break
+            return
 
     def api_data_to_list(items):
         result = []
@@ -167,7 +198,7 @@ def generate_value(item_id):
     sales_data = api_data_to_list(decoded["priceDataPoints"])
     volume_data = api_data_to_list(decoded["volumeDataPoints"])
     if sales_data is None or volume_data is None:
-        log(f"Failed to parse_date of {item_id}, skipping it")
+        log(f"Failed to parse_date of {resale_id}, skipping it")
         return None
 
     now = time.time()
@@ -407,19 +438,20 @@ def generate_value(item_id):
         return new_algorithm()
 
 
-def get_value(item_id):
+def get_value(item):
     """
     Returns a generated value, will return NONE if it fails to parse the item date
     """
+    item_id = item["itemId"]
 
     if item_id in values:
         data = values[item_id]
         # Force regeneration of value every day
         if time.time() - data["timestamp"] >= 86400:
-            item_value = generate_value(item_id)
+            item_value = generate_value(item)
         else:
             item_value = data
     else:
-        item_value = generate_value(item_id)
+        item_value = generate_value(item)
 
     return item_value


### PR DESCRIPTION
# Migrate to V2 APIs and fix trading faces.

Since Roblox migrated all faces to a new system, pull_trade returns the error:
`"The trade contains bundle items and cannot be processed by the legacy endpoints"`

To resolve this, all functions listed in the title have been migrated to the correct V2 APIs.

The primary change was updating `get_inventory` to use:
`https://trades.roblox.com/v2/users/{user_id}/tradableItems?sortBy=CreationTime&sortOrder=2&limit=100&cursor={cursor}`
```json
{
  "userId": 99212620,
  "items": [
    {
      "collectibleItemId": "534cabac-7785-4b2c-88b9-60c470cbf16a",
      "itemTarget": {
        "itemType": "Bundle",
        "targetId": "149363664010741"
      },
      "itemName": "Pink Shades McCool",
      "originalPrice": 25,
      "recentAveragePrice": 6551,
      "assetStock": 6005,
      "instances": [
        {
          "collectibleItemInstanceId": "c488638f-1d35-446b-a008-146745a93dd3",
          "itemTarget": {
            "itemType": "Bundle",
            "targetId": "149363664010741"
          },
          "itemName": "Pink Shades McCool",
          "serialNumber": 2409,
          "originalPrice": 25,
          "recentAveragePrice": 6551,
          "assetStock": 6005,
          "isOnHold": false
        }
      ]
    }
  ]
}
```
This response provides all item data needed for the V2 APIs. `collectibleItemId` maps to the legacy `AssetId`, and `collectibleItemInstanceId` maps to the legacy `UserAssetId`.

# ETC
- Refactor getting inventory, using trade API. fix small bugs, like find_people being in an infinite loop because the item_id is invalid.
- Add exceptions to all get_inventory calls and improve rate-limits.
- Fix can_trade API getting spammed even when ratelimited.
- Add ratelimits that increase each time the API gets ratelimited to can_trade and resale_data